### PR TITLE
Fix blockquote multi-line rendering with proper line breaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 dist
+
+.DS_Store
+CLAUDE.md

--- a/example/example.md
+++ b/example/example.md
@@ -19,14 +19,15 @@ This is **formatted** text inside of a generic tag.
 ## Blockquote
 
 > This is a **sample** blockquote
+> This is a second line of the blockquote
 
 ## Bulleted list
 
 * This is a sample list
 * This is another list item
-    * This is an indented list item
-        * This is a deeply nested item
-    * This is another indented list item
+  * This is an indented list item
+    * This is a deeply nested item
+  * This is another indented list item
 
 ## Table
 

--- a/src/renderBlock.ts
+++ b/src/renderBlock.ts
@@ -8,6 +8,37 @@ import type { Config } from '@markdoc/markdoc';
 import type { DecorationSet } from '@codemirror/view'
 import type { EditorState, Range } from '@codemirror/state';
 
+const defaultConfig: Config = {
+  nodes: {
+    blockquote: {
+      render: 'blockquote',
+      transform(node, config) {
+        const children = node.transformChildren(config);
+        return new markdoc.Tag('blockquote', {}, children);
+      }
+    },
+    paragraph: {
+      render: 'p',
+      transform(node, config) {
+        const children = node.transformChildren(config);
+        return new markdoc.Tag('p', {}, children);
+      }
+    },
+    softbreak: {
+      render: 'br',
+      transform() {
+        return new markdoc.Tag('br', {});
+      }
+    },
+    hardbreak: {
+      render: 'br',
+      transform() {
+        return new markdoc.Tag('br', {});
+      }
+    }
+  }
+};
+
 const patternTag = /{%\s*(?<closing>\/)?(?<tag>[a-zA-Z0-9-_]+)(?<attrs>\s+[^]+)?\s*(?<self>\/)?%}\s*$/m;
 
 class RenderBlockWidget extends WidgetType {
@@ -16,8 +47,14 @@ class RenderBlockWidget extends WidgetType {
   constructor(public source: string, config: Config) {
     super();
 
+    const mergedConfig = {
+      ...defaultConfig,
+      nodes: { ...defaultConfig.nodes, ...config.nodes },
+      tags: { ...defaultConfig.tags, ...config.tags }
+    };
+
     const document = markdoc.parse(source);
-    const transformed = markdoc.transform(document, config);
+    const transformed = markdoc.transform(document, mergedConfig);
     this.rendered = markdoc.renderers.html(transformed);
   }
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where multiple lines within blockquotes were being rendered on a single line instead of preserving the intended line breaks. Previously, blockquotes with multiple lines would display as concatenated text, making them difficult to read and not matching the expected markdown formatting behavior.

The fix introduces a default Markdoc configuration within the core plugin that properly handles `softbreak` and `hardbreak` nodes by converting them to `<br>` tags. This default config is automatically merged with any user-provided configuration, ensuring blockquotes work correctly out-of-the-box while maintaining full customization capabilities.

## Test plan

- [x] Setup example environment (`cd example && npm install && npm start`)
- [x] Navigate to http://localhost:8000 and verify blockquote section shows two separate lines
- [x] Test cursor interaction - raw markdown appears when clicking within blockquote
- [x] Verify rendered view returns with proper line separation when clicking outside
- [x] Confirm other rendering features (tables, lists, tags) continue working as expected
- [x] Verify custom Markdoc configurations are not interfered with

**Before**: Blockquote lines were concatenated on single line
**After**: Each blockquote line is properly separated with line breaks